### PR TITLE
handle application/json content-type headers with charset info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .bundle
+.idea
 .config
 .yardoc
 Gemfile.lock

--- a/lib/restfulness/request.rb
+++ b/lib/restfulness/request.rb
@@ -53,7 +53,7 @@ module Restfulness
     def params
       return @params if @params || body.nil?
       case headers[:content_type]
-      when 'application/json'
+      when /application\/json/
         @params = MultiJson.decode(body)
       else
         raise HTTPException.new(406)

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -106,6 +106,15 @@ describe Restfulness::Request do
         obj.params
       }.to raise_error(Restfulness::HTTPException, "Not Acceptable")
     end
+
+    it "should decode a JSON body with utf-8 encoding" do
+      obj.headers[:content_type] = "application/json; charset=utf-8"
+      obj.body = "{\"foo\":\"bar\"}"
+      expect {
+        obj.params
+      }.not_to raise_error
+    end
+
     it "should decode a JSON body" do
       obj.headers[:content_type] = "application/json"
       obj.body = "{\"foo\":\"bar\"}"


### PR DESCRIPTION
This diff updates the request handling to better parse the "content-type" header, allowing for values such as `application/json; charset=utf-8` to still be recognized as json requests.
