### PR TITLE
Expose rack env on the Restfulness::Request, initialized from the rack dispatcher

### DIFF
--- a/lib/restfulness/dispatchers/rack.rb
+++ b/lib/restfulness/dispatchers/rack.rb
@@ -21,6 +21,7 @@ module Restfulness
         rack_req = ::Rack::Request.new(env)
 
         request = Request.new(app)
+        request.rack_env = env
 
         request.uri        = rack_req.url
         request.action     = parse_action(env, rack_req.request_method)

--- a/lib/restfulness/request.rb
+++ b/lib/restfulness/request.rb
@@ -1,11 +1,14 @@
 module Restfulness
 
   # Simple, indpendent, request interface for dealing with the incoming information
-  # in a request. 
+  # in a request.
   #
   # Currently wraps around the information provided in a Rack Request object.
   class Request
     include Requests::Authorization
+
+    # Expose rack env to interact with rack middleware
+    attr_accessor :rack_env
 
     # Who does this request belong to?
     attr_reader :app
@@ -110,7 +113,7 @@ module Restfulness
           body.read
         else
           body
-        end     
+        end
       else
         ""
       end

--- a/spec/unit/dispatchers/rack_spec.rb
+++ b/spec/unit/dispatchers/rack_spec.rb
@@ -16,7 +16,7 @@ describe Restfulness::Dispatchers::Rack do
   let :app do
     Class.new(Restfulness::Application) {
       routes do
-        add 'projects', RackExampleResource 
+        add 'projects', RackExampleResource
       end
     }.new
   end
@@ -102,6 +102,7 @@ describe Restfulness::Dispatchers::Rack do
       req.headers.keys.should include(:x_auth_token)
       req.remote_ip.should eql('192.168.1.23')
       req.user_agent.should eql('Some Navigator')
+      req.rack_env.should be env
 
       req.query.should_not be_empty
       req.query[:query].should eql('test')


### PR DESCRIPTION
In order to interface with other rack middleware, we need to be able to read and write to the rack env hash.

One example use case is populating the person data for the Rollbar service (see [Person tracking with rack applications](https://rollbar.com/docs/notifier/rollbar-gem/#person-tracking))