### PR TITLE
Don't initialize AuthorizationHeader when authorization is blank

### DIFF
--- a/lib/restfulness/requests/authorization.rb
+++ b/lib/restfulness/requests/authorization.rb
@@ -6,7 +6,7 @@ module Restfulness
       def authorization
         @authorization ||= begin
           payload = authorization_header_payload
-          AuthorizationHeader.new(payload) unless payload.nil?
+          AuthorizationHeader.new(payload) unless payload.blank?
         end
       end
 
@@ -15,8 +15,6 @@ module Restfulness
       def authorization_header_payload
         headers[:authorization]
       end
-
     end
-
   end
 end

--- a/spec/unit/requests/authorization_spec.rb
+++ b/spec/unit/requests/authorization_spec.rb
@@ -14,8 +14,13 @@ describe Restfulness::Requests::Authorization do
   end
 
   describe "#authorization" do
-
     it "should be nil if no authorization header resent" do
+      auth = request.authorization
+      expect(auth).to be_nil
+    end
+
+    it "should be nil if authorization header is blank" do
+      request.headers[:authorization] = ""
       auth = request.authorization
       expect(auth).to be_nil
     end
@@ -26,7 +31,5 @@ describe Restfulness::Requests::Authorization do
       expect(auth).to be_a(Restfulness::Requests::AuthorizationHeader)
       expect(auth.schema).to eql("Basic")
     end
-
- end
-
+  end
 end


### PR DESCRIPTION
In some cases, the `Authorization` header comes as a empty string which is causing an exception when the `AuthorizationHeader` class [tries to slice a nil](https://github.com/samlown/restfulness/blob/master/lib/restfulness/requests/authorization_header.rb#L16).

This PR replace the `payload.nil?` check with `payload.blank?` with prevent the creation of a `AuthorizationHeader` with a empty string payload.