### PR TITLE
Fixing overriding content type and support for xml responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,11 @@ Restfulness is still a work in progress but at Cabify we are using it in product
 
 ## History
 
+### 0.3.6 - pending
+
+ * Fixing issue for overriding response Content-Type headers (@samlown)
+ * Adding basic support for XML responses if requested in Accept headers (@samlown)
+
 ### 0.3.5 - February 21, 2017
 
  * Rewind body after reading (@pacoguzman)

--- a/lib/restfulness/headers/accept.rb
+++ b/lib/restfulness/headers/accept.rb
@@ -60,6 +60,13 @@ module Restfulness
         false
       end
 
+      def text?
+        media_types.each do |mt|
+          return true if mt.text?
+        end 
+        false
+      end
+
     end
 
   end

--- a/restfulness.gemspec
+++ b/restfulness.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "builder"
+
 end

--- a/spec/unit/headers/accept_spec.rb
+++ b/spec/unit/headers/accept_spec.rb
@@ -61,9 +61,20 @@ describe Restfulness::Headers::Accept do
       obj = klass.new("text/plain, application/xml; version=1, text/*")
       expect(obj.xml?).to be true
     end
-    it "should confirm if json not accepted" do
+    it "should confirm if xml not accepted" do
       obj = klass.new("text/plain, application/json, text/*")
       expect(obj.xml?).to be false
+    end
+  end
+
+  describe "#text?" do
+    it "should confirm if content includes text" do
+      obj = klass.new("text/plain, text/*")
+      expect(obj.text?).to be true
+    end
+    it "should confirm if text not accepted" do
+      obj = klass.new("application/json")
+      expect(obj.text?).to be false
     end
   end
 


### PR DESCRIPTION
Small PR with two key changes:

 * Support for overriding the content type manually, if needed.
 * Support for xml responses and automatic building via `to_xml` if XML is requested in the HTTP `Accept` header.